### PR TITLE
ADD-Gitignore: coverage, Gem:Pry-Rails,Rails_Helper: formatter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   gem 'orderly'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'pry-rails' #returns data in organized and color coded
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.1)
     puma (3.12.6)
     racc (1.6.0)
@@ -236,6 +238,7 @@ DEPENDENCIES
   orderly
   pg (>= 0.18, < 2.0)
   pry
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.6)
   rspec-rails (~> 4.0.1)

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1,7 +1,7 @@
 {
   "RSpec": {
     "coverage": {
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/environment.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/environment.rb": {
         "lines": [
           null,
           1,
@@ -10,7 +10,7 @@
           1
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/application.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/application.rb": {
         "lines": [
           1,
           null,
@@ -33,7 +33,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/boot.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/boot.rb": {
         "lines": [
           1,
           null,
@@ -41,7 +41,7 @@
           1
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/environments/test.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/environments/test.rb": {
         "lines": [
           1,
           null,
@@ -91,7 +91,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/initializers/application_controller_renderer.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/initializers/application_controller_renderer.rb": {
         "lines": [
           null,
           null,
@@ -103,7 +103,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/initializers/assets.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/initializers/assets.rb": {
         "lines": [
           null,
           null,
@@ -121,7 +121,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/initializers/backtrace_silencers.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/initializers/backtrace_silencers.rb": {
         "lines": [
           null,
           null,
@@ -132,7 +132,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/initializers/content_security_policy.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/initializers/content_security_policy.rb": {
         "lines": [
           null,
           null,
@@ -161,7 +161,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/initializers/cookies_serializer.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/initializers/cookies_serializer.rb": {
         "lines": [
           null,
           null,
@@ -170,7 +170,7 @@
           1
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/initializers/filter_parameter_logging.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/initializers/filter_parameter_logging.rb": {
         "lines": [
           null,
           null,
@@ -178,7 +178,7 @@
           1
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/initializers/inflections.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/initializers/inflections.rb": {
         "lines": [
           null,
           null,
@@ -198,7 +198,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/initializers/mime_types.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/initializers/mime_types.rb": {
         "lines": [
           null,
           null,
@@ -206,7 +206,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/initializers/new_framework_defaults_5_2.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/initializers/new_framework_defaults_5_2.rb": {
         "lines": [
           null,
           null,
@@ -248,7 +248,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/initializers/wrap_parameters.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/initializers/wrap_parameters.rb": {
         "lines": [
           null,
           null,
@@ -266,7 +266,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/config/routes.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/config/routes.rb": {
         "lines": [
           1,
           null,
@@ -274,71 +274,13 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/app/helpers/application_helper.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/app/helpers/application_helper.rb": {
         "lines": [
           1,
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/spec/models/customer_spec.rb": {
-        "lines": [
-          1,
-          null,
-          1,
-          1,
-          2,
-          2,
-          null,
-          null,
-          1,
-          2,
-          2,
-          null,
-          null
-        ]
-      },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/app/models/customer.rb": {
-        "lines": [
-          1,
-          1,
-          1,
-          null,
-          1,
-          null
-        ]
-      },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/app/models/application_record.rb": {
-        "lines": [
-          1,
-          1,
-          null
-        ]
-      },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/spec/models/invoice_item_spec.rb": {
-        "lines": [
-          1,
-          null,
-          1,
-          1,
-          2,
-          2,
-          null,
-          null
-        ]
-      },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/app/models/invoice_item.rb": {
-        "lines": [
-          1,
-          1,
-          1,
-          null,
-          1,
-          null,
-          null,
-          null
-        ]
-      },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/spec/models/invoice_spec.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/spec/models/customer_spec.rb": {
         "lines": [
           1,
           null,
@@ -350,11 +292,69 @@
           null,
           1,
           2,
+          2,
           null,
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/app/models/invoice.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/app/models/customer.rb": {
+        "lines": [
+          1,
+          1,
+          1,
+          null,
+          1,
+          null
+        ]
+      },
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/app/models/application_record.rb": {
+        "lines": [
+          1,
+          1,
+          null
+        ]
+      },
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/spec/models/invoice_item_spec.rb": {
+        "lines": [
+          1,
+          null,
+          1,
+          1,
+          2,
+          2,
+          null,
+          null
+        ]
+      },
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/app/models/invoice_item.rb": {
+        "lines": [
+          1,
+          1,
+          1,
+          null,
+          1,
+          null,
+          null,
+          null
+        ]
+      },
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/spec/models/invoice_spec.rb": {
+        "lines": [
+          1,
+          null,
+          1,
+          1,
+          2,
+          2,
+          null,
+          null,
+          1,
+          2,
+          null,
+          null
+        ]
+      },
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/app/models/invoice.rb": {
         "lines": [
           1,
           1,
@@ -368,7 +368,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/spec/models/item_spec.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/spec/models/item_spec.rb": {
         "lines": [
           1,
           null,
@@ -388,7 +388,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/app/models/item.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/app/models/item.rb": {
         "lines": [
           1,
           1,
@@ -400,7 +400,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/spec/models/merchant_spec.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/spec/models/merchant_spec.rb": {
         "lines": [
           1,
           null,
@@ -415,7 +415,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/app/models/merchant.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/app/models/merchant.rb": {
         "lines": [
           1,
           1,
@@ -424,7 +424,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/spec/models/transaction_spec.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/spec/models/transaction_spec.rb": {
         "lines": [
           1,
           null,
@@ -441,7 +441,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/app/models/transaction.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/app/models/transaction.rb": {
         "lines": [
           1,
           1,
@@ -453,7 +453,7 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/app/controllers/admin_controller.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/app/controllers/admin_controller.rb": {
         "lines": [
           1,
           1,
@@ -461,13 +461,13 @@
           null
         ]
       },
-      "/Users/bryanflanagan/turing_work/2mod/projects/little-esty-shop/app/controllers/application_controller.rb": {
+      "/Users/sergioazcona/Desktop/turing_work/2mod_REDUX/projects/little-esty-shop/app/controllers/application_controller.rb": {
         "lines": [
           1,
           null
         ]
       }
     },
-    "timestamp": 1672760256
+    "timestamp": 1672762012
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,7 +14,7 @@
       <img src="./assets/0.12.3/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2023-01-03T08:37:36-07:00">2023-01-03T08:37:36-07:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2023-01-03T11:06:52-05:00">2023-01-03T11:06:52-05:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -71,7 +71,7 @@
       <tbody>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#9ba175c57977d6571453669a1356742473188214" class="src_link" title="app/controllers/admin_controller.rb">app/controllers/admin_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#4c41bdd780fe4e8f5c7ff84c05019e0e4f0b6892" class="src_link" title="app/controllers/admin_controller.rb">app/controllers/admin_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">4</td>
             <td class="cell--number">2</td>
@@ -82,7 +82,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#22d83f6afd0696bd4ad7969b9bb1fb3a909a05fa" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#60f011a56685c93caae36b2858765bfa407956bf" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -93,7 +93,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#e2856041a617270ca7c7f0fa72234c877d3fa56e" class="src_link" title="app/helpers/application_helper.rb">app/helpers/application_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#7a6bceb614d341285f40106f8167ba0d4e48be04" class="src_link" title="app/helpers/application_helper.rb">app/helpers/application_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -104,7 +104,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#b1393b3f7321e64be18de5cd2fda8ba1c6d0b5d6" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
+            <td class="strong t-file__name"><a href="#91dbecc57f1fb54ceea0f8791c4756e24f905a46" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">3</td>
             <td class="cell--number">2</td>
@@ -115,7 +115,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#5a3e4660fb2c2704caa06e8a767f9fef0198fa20" class="src_link" title="app/models/customer.rb">app/models/customer.rb</a></td>
+            <td class="strong t-file__name"><a href="#9ab6b174d62efa89162cfe4ef800b3ce1c25a4b9" class="src_link" title="app/models/customer.rb">app/models/customer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">6</td>
             <td class="cell--number">4</td>
@@ -126,7 +126,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#2b31ee7bfb00b939b2880ea4f84c5402df0000e2" class="src_link" title="app/models/invoice.rb">app/models/invoice.rb</a></td>
+            <td class="strong t-file__name"><a href="#5eacc3260638d3e43643f6f1070010c692feabd7" class="src_link" title="app/models/invoice.rb">app/models/invoice.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">10</td>
             <td class="cell--number">5</td>
@@ -137,7 +137,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#77c50350b57ba67a00215eade6663e7723106384" class="src_link" title="app/models/invoice_item.rb">app/models/invoice_item.rb</a></td>
+            <td class="strong t-file__name"><a href="#64d7d79742bd1b73f2b9c5b450632a788e3fd366" class="src_link" title="app/models/invoice_item.rb">app/models/invoice_item.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">8</td>
             <td class="cell--number">4</td>
@@ -148,7 +148,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#61aae898113905864a3f54df7274c44dcd2a8a68" class="src_link" title="app/models/item.rb">app/models/item.rb</a></td>
+            <td class="strong t-file__name"><a href="#cf97fe1456eddb8ac776a8603ebf7af80874d02b" class="src_link" title="app/models/item.rb">app/models/item.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">8</td>
             <td class="cell--number">6</td>
@@ -159,7 +159,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#0219a03e5a610b61e1181ea6ae88d77dd8538df3" class="src_link" title="app/models/merchant.rb">app/models/merchant.rb</a></td>
+            <td class="strong t-file__name"><a href="#58f44613132162b13bbf8fb54059b3967512393d" class="src_link" title="app/models/merchant.rb">app/models/merchant.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">5</td>
             <td class="cell--number">3</td>
@@ -170,7 +170,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#16b6fe01a77864a965f034d2e5970bdd37f95f2a" class="src_link" title="app/models/transaction.rb">app/models/transaction.rb</a></td>
+            <td class="strong t-file__name"><a href="#b1a422bb0dd97e871b49a1e229a922b09e31c4d5" class="src_link" title="app/models/transaction.rb">app/models/transaction.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">8</td>
             <td class="cell--number">5</td>
@@ -181,7 +181,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#695cd8d9dc6101d40a54a55266d7409718b4a52e" class="src_link" title="config/application.rb">config/application.rb</a></td>
+            <td class="strong t-file__name"><a href="#f6b965d3562cf99cae4bfbf6ab813d017e15ecee" class="src_link" title="config/application.rb">config/application.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">19</td>
             <td class="cell--number">6</td>
@@ -192,7 +192,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#e0cedb2d42caabb5c5a92bbc1b55644b50f1feb1" class="src_link" title="config/boot.rb">config/boot.rb</a></td>
+            <td class="strong t-file__name"><a href="#763e50776b21cd4bd9fcd3ace517e5520595def9" class="src_link" title="config/boot.rb">config/boot.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">4</td>
             <td class="cell--number">3</td>
@@ -203,7 +203,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#d99421acfd8c75d84a85b2fc9fdd27eb10736ebc" class="src_link" title="config/environment.rb">config/environment.rb</a></td>
+            <td class="strong t-file__name"><a href="#f60a832c51312050d6d3b7ede6e453acb7372e53" class="src_link" title="config/environment.rb">config/environment.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">5</td>
             <td class="cell--number">2</td>
@@ -214,7 +214,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#f42eb889a10428007f44322c7bd05dca98425b75" class="src_link" title="config/environments/test.rb">config/environments/test.rb</a></td>
+            <td class="strong t-file__name"><a href="#d2293805012119d18c3b10dea2eae1bbc3a22bff" class="src_link" title="config/environments/test.rb">config/environments/test.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">46</td>
             <td class="cell--number">13</td>
@@ -225,7 +225,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#2b420f77789ec950931061265992819d7468ef9e" class="src_link" title="config/initializers/application_controller_renderer.rb">config/initializers/application_controller_renderer.rb</a></td>
+            <td class="strong t-file__name"><a href="#4afa9eaa5950accee16866307cb47a478f707012" class="src_link" title="config/initializers/application_controller_renderer.rb">config/initializers/application_controller_renderer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">8</td>
             <td class="cell--number">0</td>
@@ -236,7 +236,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#a151689b7a061a221a13b4076d808a1c8c536e62" class="src_link" title="config/initializers/assets.rb">config/initializers/assets.rb</a></td>
+            <td class="strong t-file__name"><a href="#d1dd822bf81e6dbed1234e4913c098acda63b722" class="src_link" title="config/initializers/assets.rb">config/initializers/assets.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">14</td>
             <td class="cell--number">2</td>
@@ -247,7 +247,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#56963e6d927ad7d3812252e764c3cb0a312fc3ea" class="src_link" title="config/initializers/backtrace_silencers.rb">config/initializers/backtrace_silencers.rb</a></td>
+            <td class="strong t-file__name"><a href="#cfe5aaa14508cb3be3353f11b2e561beb1a7c1c0" class="src_link" title="config/initializers/backtrace_silencers.rb">config/initializers/backtrace_silencers.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">7</td>
             <td class="cell--number">0</td>
@@ -258,7 +258,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#ee3dbdcf0c49248dfb5287601db9049d34a49c6d" class="src_link" title="config/initializers/content_security_policy.rb">config/initializers/content_security_policy.rb</a></td>
+            <td class="strong t-file__name"><a href="#eca13e5bc1b7d7765649af637b43fa909bce4c8d" class="src_link" title="config/initializers/content_security_policy.rb">config/initializers/content_security_policy.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">25</td>
             <td class="cell--number">0</td>
@@ -269,7 +269,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#90f384c0994bc10864068037adbf4594fc18bfb5" class="src_link" title="config/initializers/cookies_serializer.rb">config/initializers/cookies_serializer.rb</a></td>
+            <td class="strong t-file__name"><a href="#257cae2fb75c5dfe599a37d3501925f4a045e63a" class="src_link" title="config/initializers/cookies_serializer.rb">config/initializers/cookies_serializer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">5</td>
             <td class="cell--number">1</td>
@@ -280,7 +280,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#d9ab0f1e0d4e9e725fb22868e3148a35f49bedda" class="src_link" title="config/initializers/filter_parameter_logging.rb">config/initializers/filter_parameter_logging.rb</a></td>
+            <td class="strong t-file__name"><a href="#3ea879c70723a37d66ae4f7f815518340b50fd6b" class="src_link" title="config/initializers/filter_parameter_logging.rb">config/initializers/filter_parameter_logging.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">4</td>
             <td class="cell--number">1</td>
@@ -291,7 +291,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#4b10903dfbdc72c64d487e1e544bd54d13f0d6e5" class="src_link" title="config/initializers/inflections.rb">config/initializers/inflections.rb</a></td>
+            <td class="strong t-file__name"><a href="#9c0e2de7e3d7c119fe5b689114496b16795ca0ba" class="src_link" title="config/initializers/inflections.rb">config/initializers/inflections.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">16</td>
             <td class="cell--number">0</td>
@@ -302,7 +302,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#ab4c42afe2716827559a70064c79e7fa97ab8751" class="src_link" title="config/initializers/mime_types.rb">config/initializers/mime_types.rb</a></td>
+            <td class="strong t-file__name"><a href="#5886821b7912706792ac7ae5522873c8361aa843" class="src_link" title="config/initializers/mime_types.rb">config/initializers/mime_types.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">4</td>
             <td class="cell--number">0</td>
@@ -313,7 +313,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#be5c46de602da325920226b195b527df013ca54f" class="src_link" title="config/initializers/new_framework_defaults_5_2.rb">config/initializers/new_framework_defaults_5_2.rb</a></td>
+            <td class="strong t-file__name"><a href="#5db8841207c52aaa836e56a37bee810daa38f655" class="src_link" title="config/initializers/new_framework_defaults_5_2.rb">config/initializers/new_framework_defaults_5_2.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">38</td>
             <td class="cell--number">0</td>
@@ -324,7 +324,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#6c27bf183743fc6607e61b64927b169d929ad285" class="src_link" title="config/initializers/wrap_parameters.rb">config/initializers/wrap_parameters.rb</a></td>
+            <td class="strong t-file__name"><a href="#137f7b6f418cbdba62b27cae814d9ade4ca42dec" class="src_link" title="config/initializers/wrap_parameters.rb">config/initializers/wrap_parameters.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">14</td>
             <td class="cell--number">2</td>
@@ -335,7 +335,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#bed47571812f433559f6f63d637fca5a31e2470b" class="src_link" title="config/routes.rb">config/routes.rb</a></td>
+            <td class="strong t-file__name"><a href="#f1ce610150637d2225e3c507a1a49da2884b8172" class="src_link" title="config/routes.rb">config/routes.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">4</td>
             <td class="cell--number">2</td>
@@ -346,7 +346,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#b2b532276e0950683366a53db0d2873eb4529431" class="src_link" title="spec/models/customer_spec.rb">spec/models/customer_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#a1b7061cb7bfdab8975bef771ceb2b528c8aa59a" class="src_link" title="spec/models/customer_spec.rb">spec/models/customer_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">13</td>
             <td class="cell--number">8</td>
@@ -357,7 +357,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#e17b2367573f7dd228b89c27f6781d03410ca754" class="src_link" title="spec/models/invoice_item_spec.rb">spec/models/invoice_item_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#2a9d51e3f3ac1b7c2da97ec74c44ba740aaa5f2f" class="src_link" title="spec/models/invoice_item_spec.rb">spec/models/invoice_item_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">8</td>
             <td class="cell--number">5</td>
@@ -368,7 +368,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#dd2e0da05c9fd1a5ce79b6ed20f88200253d719a" class="src_link" title="spec/models/invoice_spec.rb">spec/models/invoice_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#49f48e4fa111ff4568885096d8cd38ca73ed1c9c" class="src_link" title="spec/models/invoice_spec.rb">spec/models/invoice_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">12</td>
             <td class="cell--number">7</td>
@@ -379,7 +379,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#19d76aaf2856788d60d77c494f3935473a9041e5" class="src_link" title="spec/models/item_spec.rb">spec/models/item_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#fba4c866aeb30e1f58917047f8fe5d0672c3d460" class="src_link" title="spec/models/item_spec.rb">spec/models/item_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">16</td>
             <td class="cell--number">11</td>
@@ -390,7 +390,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#41a80b2ec43c3b4589ef7722f476e9a021fc7e78" class="src_link" title="spec/models/merchant_spec.rb">spec/models/merchant_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#ed41349c36762bc7cbca4a24e7f469833f48a8d1" class="src_link" title="spec/models/merchant_spec.rb">spec/models/merchant_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -401,7 +401,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#677944a2ac7cfdd0d139528808308cf0498bbb59" class="src_link" title="spec/models/transaction_spec.rb">spec/models/transaction_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#ff0ca4bc63718a5e3b2124bd3139432e6cdc52d2" class="src_link" title="spec/models/transaction_spec.rb">spec/models/transaction_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">13</td>
             <td class="cell--number">8</td>
@@ -428,7 +428,7 @@
 
       <div class="source_files">
       
-        <div class="source_table" id="9ba175c57977d6571453669a1356742473188214">
+        <div class="source_table" id="4c41bdd780fe4e8f5c7ff84c05019e0e4f0b6892">
   <div class="header">
     <h3>app/controllers/admin_controller.rb</h3>
     <h4>
@@ -503,7 +503,7 @@
 </div>
 
       
-        <div class="source_table" id="22d83f6afd0696bd4ad7969b9bb1fb3a909a05fa">
+        <div class="source_table" id="60f011a56685c93caae36b2858765bfa407956bf">
   <div class="header">
     <h3>app/controllers/application_controller.rb</h3>
     <h4>
@@ -556,7 +556,7 @@
 </div>
 
       
-        <div class="source_table" id="e2856041a617270ca7c7f0fa72234c877d3fa56e">
+        <div class="source_table" id="7a6bceb614d341285f40106f8167ba0d4e48be04">
   <div class="header">
     <h3>app/helpers/application_helper.rb</h3>
     <h4>
@@ -609,7 +609,7 @@
 </div>
 
       
-        <div class="source_table" id="b1393b3f7321e64be18de5cd2fda8ba1c6d0b5d6">
+        <div class="source_table" id="91dbecc57f1fb54ceea0f8791c4756e24f905a46">
   <div class="header">
     <h3>app/models/application_record.rb</h3>
     <h4>
@@ -673,7 +673,7 @@
 </div>
 
       
-        <div class="source_table" id="5a3e4660fb2c2704caa06e8a767f9fef0198fa20">
+        <div class="source_table" id="9ab6b174d62efa89162cfe4ef800b3ce1c25a4b9">
   <div class="header">
     <h3>app/models/customer.rb</h3>
     <h4>
@@ -770,7 +770,7 @@
 </div>
 
       
-        <div class="source_table" id="2b31ee7bfb00b939b2880ea4f84c5402df0000e2">
+        <div class="source_table" id="5eacc3260638d3e43643f6f1070010c692feabd7">
   <div class="header">
     <h3>app/models/invoice.rb</h3>
     <h4>
@@ -911,7 +911,7 @@
 </div>
 
       
-        <div class="source_table" id="77c50350b57ba67a00215eade6663e7723106384">
+        <div class="source_table" id="64d7d79742bd1b73f2b9c5b450632a788e3fd366">
   <div class="header">
     <h3>app/models/invoice_item.rb</h3>
     <h4>
@@ -1030,7 +1030,7 @@
 </div>
 
       
-        <div class="source_table" id="61aae898113905864a3f54df7274c44dcd2a8a68">
+        <div class="source_table" id="cf97fe1456eddb8ac776a8603ebf7af80874d02b">
   <div class="header">
     <h3>app/models/item.rb</h3>
     <h4>
@@ -1149,7 +1149,7 @@
 </div>
 
       
-        <div class="source_table" id="0219a03e5a610b61e1181ea6ae88d77dd8538df3">
+        <div class="source_table" id="58f44613132162b13bbf8fb54059b3967512393d">
   <div class="header">
     <h3>app/models/merchant.rb</h3>
     <h4>
@@ -1235,7 +1235,7 @@
 </div>
 
       
-        <div class="source_table" id="16b6fe01a77864a965f034d2e5970bdd37f95f2a">
+        <div class="source_table" id="b1a422bb0dd97e871b49a1e229a922b09e31c4d5">
   <div class="header">
     <h3>app/models/transaction.rb</h3>
     <h4>
@@ -1354,7 +1354,7 @@
 </div>
 
       
-        <div class="source_table" id="695cd8d9dc6101d40a54a55266d7409718b4a52e">
+        <div class="source_table" id="f6b965d3562cf99cae4bfbf6ab813d017e15ecee">
   <div class="header">
     <h3>config/application.rb</h3>
     <h4>
@@ -1594,7 +1594,7 @@
 </div>
 
       
-        <div class="source_table" id="e0cedb2d42caabb5c5a92bbc1b55644b50f1feb1">
+        <div class="source_table" id="763e50776b21cd4bd9fcd3ace517e5520595def9">
   <div class="header">
     <h3>config/boot.rb</h3>
     <h4>
@@ -1669,7 +1669,7 @@
 </div>
 
       
-        <div class="source_table" id="d99421acfd8c75d84a85b2fc9fdd27eb10736ebc">
+        <div class="source_table" id="f60a832c51312050d6d3b7ede6e453acb7372e53">
   <div class="header">
     <h3>config/environment.rb</h3>
     <h4>
@@ -1755,7 +1755,7 @@
 </div>
 
       
-        <div class="source_table" id="f42eb889a10428007f44322c7bd05dca98425b75">
+        <div class="source_table" id="d2293805012119d18c3b10dea2eae1bbc3a22bff">
   <div class="header">
     <h3>config/environments/test.rb</h3>
     <h4>
@@ -2292,7 +2292,7 @@
 </div>
 
       
-        <div class="source_table" id="2b420f77789ec950931061265992819d7468ef9e">
+        <div class="source_table" id="4afa9eaa5950accee16866307cb47a478f707012">
   <div class="header">
     <h3>config/initializers/application_controller_renderer.rb</h3>
     <h4>
@@ -2411,7 +2411,7 @@
 </div>
 
       
-        <div class="source_table" id="a151689b7a061a221a13b4076d808a1c8c536e62">
+        <div class="source_table" id="d1dd822bf81e6dbed1234e4913c098acda63b722">
   <div class="header">
     <h3>config/initializers/assets.rb</h3>
     <h4>
@@ -2596,7 +2596,7 @@
 </div>
 
       
-        <div class="source_table" id="56963e6d927ad7d3812252e764c3cb0a312fc3ea">
+        <div class="source_table" id="cfe5aaa14508cb3be3353f11b2e561beb1a7c1c0">
   <div class="header">
     <h3>config/initializers/backtrace_silencers.rb</h3>
     <h4>
@@ -2704,7 +2704,7 @@
 </div>
 
       
-        <div class="source_table" id="ee3dbdcf0c49248dfb5287601db9049d34a49c6d">
+        <div class="source_table" id="eca13e5bc1b7d7765649af637b43fa909bce4c8d">
   <div class="header">
     <h3>config/initializers/content_security_policy.rb</h3>
     <h4>
@@ -3010,7 +3010,7 @@
 </div>
 
       
-        <div class="source_table" id="90f384c0994bc10864068037adbf4594fc18bfb5">
+        <div class="source_table" id="257cae2fb75c5dfe599a37d3501925f4a045e63a">
   <div class="header">
     <h3>config/initializers/cookies_serializer.rb</h3>
     <h4>
@@ -3096,7 +3096,7 @@
 </div>
 
       
-        <div class="source_table" id="d9ab0f1e0d4e9e725fb22868e3148a35f49bedda">
+        <div class="source_table" id="3ea879c70723a37d66ae4f7f815518340b50fd6b">
   <div class="header">
     <h3>config/initializers/filter_parameter_logging.rb</h3>
     <h4>
@@ -3171,7 +3171,7 @@
 </div>
 
       
-        <div class="source_table" id="4b10903dfbdc72c64d487e1e544bd54d13f0d6e5">
+        <div class="source_table" id="9c0e2de7e3d7c119fe5b689114496b16795ca0ba">
   <div class="header">
     <h3>config/initializers/inflections.rb</h3>
     <h4>
@@ -3378,7 +3378,7 @@
 </div>
 
       
-        <div class="source_table" id="ab4c42afe2716827559a70064c79e7fa97ab8751">
+        <div class="source_table" id="5886821b7912706792ac7ae5522873c8361aa843">
   <div class="header">
     <h3>config/initializers/mime_types.rb</h3>
     <h4>
@@ -3453,7 +3453,7 @@
 </div>
 
       
-        <div class="source_table" id="be5c46de602da325920226b195b527df013ca54f">
+        <div class="source_table" id="5db8841207c52aaa836e56a37bee810daa38f655">
   <div class="header">
     <h3>config/initializers/new_framework_defaults_5_2.rb</h3>
     <h4>
@@ -3902,7 +3902,7 @@
 </div>
 
       
-        <div class="source_table" id="6c27bf183743fc6607e61b64927b169d929ad285">
+        <div class="source_table" id="137f7b6f418cbdba62b27cae814d9ade4ca42dec">
   <div class="header">
     <h3>config/initializers/wrap_parameters.rb</h3>
     <h4>
@@ -4087,7 +4087,7 @@
 </div>
 
       
-        <div class="source_table" id="bed47571812f433559f6f63d637fca5a31e2470b">
+        <div class="source_table" id="f1ce610150637d2225e3c507a1a49da2884b8172">
   <div class="header">
     <h3>config/routes.rb</h3>
     <h4>
@@ -4162,7 +4162,7 @@
 </div>
 
       
-        <div class="source_table" id="b2b532276e0950683366a53db0d2873eb4529431">
+        <div class="source_table" id="a1b7061cb7bfdab8975bef771ceb2b528c8aa59a">
   <div class="header">
     <h3>spec/models/customer_spec.rb</h3>
     <h4>
@@ -4336,7 +4336,7 @@
 </div>
 
       
-        <div class="source_table" id="e17b2367573f7dd228b89c27f6781d03410ca754">
+        <div class="source_table" id="2a9d51e3f3ac1b7c2da97ec74c44ba740aaa5f2f">
   <div class="header">
     <h3>spec/models/invoice_item_spec.rb</h3>
     <h4>
@@ -4455,7 +4455,7 @@
 </div>
 
       
-        <div class="source_table" id="dd2e0da05c9fd1a5ce79b6ed20f88200253d719a">
+        <div class="source_table" id="49f48e4fa111ff4568885096d8cd38ca73ed1c9c">
   <div class="header">
     <h3>spec/models/invoice_spec.rb</h3>
     <h4>
@@ -4618,7 +4618,7 @@
 </div>
 
       
-        <div class="source_table" id="19d76aaf2856788d60d77c494f3935473a9041e5">
+        <div class="source_table" id="fba4c866aeb30e1f58917047f8fe5d0672c3d460">
   <div class="header">
     <h3>spec/models/item_spec.rb</h3>
     <h4>
@@ -4825,7 +4825,7 @@
 </div>
 
       
-        <div class="source_table" id="41a80b2ec43c3b4589ef7722f476e9a021fc7e78">
+        <div class="source_table" id="ed41349c36762bc7cbca4a24e7f469833f48a8d1">
   <div class="header">
     <h3>spec/models/merchant_spec.rb</h3>
     <h4>
@@ -4977,7 +4977,7 @@
 </div>
 
       
-        <div class="source_table" id="677944a2ac7cfdd0d139528808308cf0498bbb59">
+        <div class="source_table" id="ff0ca4bc63718a5e3b2124bd3139432e6cdc52d2">
   <div class="header">
     <h3>spec/models/transaction_spec.rb</h3>
     <h4>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,9 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.color = true
+  config.formatter = :documentation
+  config.order = 'default'
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
adding coverage to simplecov.
ALSO, helpful tools (pry-rails; rspec formatter). the 
pry-rails: returns data in terminal in the organized way are familiar with Pry. 
formatter (rspec tool): returns the names of the tests rather than dots (color coded, i.e. green or red) when we run rspec